### PR TITLE
Fix memory leak, undefined behavior, mem alignment and more

### DIFF
--- a/src/game/game.c
+++ b/src/game/game.c
@@ -9,6 +9,7 @@
  */
 
 #include <stdint.h>
+#include <stddef.h>
 #include <SDL2/SDL.h>
 
 #include "../../src/astonia.h"
@@ -28,7 +29,8 @@ static int stat_dlsortcalls,stat_dlused;
 int namesize=DD_SMALL;
 
 DL* dl_next(void) {
-    int d,diff;
+    int d;
+    ptrdiff_t diff;
     DL *rem;
 
     if (dlused==dlmax) {

--- a/src/gui/minimap.c
+++ b/src/gui/minimap.c
@@ -207,8 +207,8 @@ void display_minimap(void) {
     if (visible==1) {
         if (update2) {
             bzero(mapix2,sizeof(mapix2));
-            for (iy=-MINIMAP; iy<=MINIMAP; iy++) {
-                for (ix=-MINIMAP; ix<=MINIMAP; ix++) {
+            for (iy=-MINIMAP; iy<MINIMAP; iy++) {
+                for (ix=-MINIMAP; ix<MINIMAP; ix++) {
 
                     dist=sqrtf(ix*ix+iy*iy);
                     if (dist>MINIMAP) continue;

--- a/src/gui/minimap.c
+++ b/src/gui/minimap.c
@@ -20,7 +20,10 @@
 
 #define MINIMAP 40
 #define MAXMAP  256
-#define IRGBA(r,g,b,a)  (((a)<<24)|((r)<<16)|((g)<<8)|((b)<<0))
+#define IRGBA(r,g,b,a)  (((uint32_t)(a)<<24)| \
+                         ((uint32_t)(r)<<16)| \
+                         ((uint32_t)(g)<<8)| \
+                         ((uint32_t)(b)<<0))
 
 static int sx,sy,visible,mx,my,update1,update2,update3,orx,ory,rewrite_cnt;
 

--- a/src/helper/convert.c
+++ b/src/helper/convert.c
@@ -57,7 +57,10 @@ void write_png_file(char *filename,uint32_t *pixel,int width,int height,int heig
 #define IGET_G(c)       ((((uint32_t)(c))>>8)&0xFF)
 #define IGET_B(c)       ((((uint32_t)(c))>>0)&0xFF)
 #define IRGB(r,g,b)     (((r)<<0)|((g)<<8)|((b)<<16))
-#define IRGBA(r,g,b,a)  (((a)<<24)|((r)<<16)|((g)<<8)|((b)<<0))
+#define IRGBA(r,g,b,a)  (((uint32_t)(a)<<24)| \
+                         ((uint32_t)(r)<<16)| \
+                         ((uint32_t)(g)<<8)| \
+                         ((uint32_t)(b)<<0))
 
 struct sdl_image {
     uint32_t *pixel;

--- a/src/sdl/_sdl.h
+++ b/src/sdl/_sdl.h
@@ -12,7 +12,10 @@
 #define IGET_G(c)       ((((uint32_t)(c))>>8)&0xFF)
 #define IGET_B(c)       ((((uint32_t)(c))>>0)&0xFF)
 #define IRGB(r,g,b)     (((r)<<0)|((g)<<8)|((b)<<16))
-#define IRGBA(r,g,b,a)  (((a)<<24)|((r)<<16)|((g)<<8)|((b)<<0))
+#define IRGBA(r,g,b,a)  (((uint32_t)(a)<<24)| \
+                         ((uint32_t)(r)<<16)| \
+                         ((uint32_t)(g)<<8)| \
+                         ((uint32_t)(b)<<0))
 
 #define SF_USED         (1<<0)
 #define SF_SPRITE       (1<<1)

--- a/src/sdl/sdl.c
+++ b/src/sdl/sdl.c
@@ -1397,7 +1397,7 @@ static inline unsigned int hashfunc_text(const char *text,int color,int flags) {
         } else t2=t3=0;
     } else t1=t2=t3=0;
 
-    hash=(t0<<0)^(t1<<3)^(t2<<6)^(t3<<9)^(color<<0)^(flags<<5);
+    hash=(t0<<0)^(t1<<3)^(t2<<6)^(t3<<9)^((uint32_t)color<<0)^((uint32_t)flags<<5);
 
     return hash%MAX_TEXHASH;
 }

--- a/src/sdl/sdl.c
+++ b/src/sdl/sdl.c
@@ -2230,7 +2230,6 @@ uint32_t *sdl_load_png(char *filename,int *dx,int *dy) {
     FILE *fp;
     png_structp png_ptr;
     png_infop info_ptr;
-    png_infop end_info;
 
     fp=fopen(filename,"rb");
     if (!fp) return NULL;
@@ -2240,9 +2239,6 @@ uint32_t *sdl_load_png(char *filename,int *dx,int *dy) {
 
     info_ptr=png_create_info_struct(png_ptr);
     if (!info_ptr) { fclose(fp); png_destroy_read_struct(&png_ptr,(png_infopp)NULL,(png_infopp)NULL); warn("create info1\n"); return NULL; }
-
-    end_info=png_create_info_struct(png_ptr);
-    if (!end_info) { fclose(fp); png_destroy_read_struct(&png_ptr,&info_ptr,(png_infopp)NULL); warn("create info2\n"); return NULL; }
 
     png_init_io(png_ptr,fp);
     png_set_strip_16(png_ptr);


### PR DESCRIPTION
I created a sanitizer build (off the linux branch I submitted a PR for) which surfaced multiple bugs upon launching the game - once I got through all of those, and the game would play, upon close I also got a detected memory leak.

This fixes all of these issues so the sanitizer no longer complains. I tried playing the game for a while, doing various kinds of actions, menu interactions, changing zones etc.

The sanitizer is now happy with nothing to report.

The only thing this PR does not include, is a pretty extensive change to client.c. The sanitizer also detected issues with byte alignment when interacting with buffer to/from network. Those changes are difficult to untangle from the newer networking interactions in client.c - so I've pushed that fix it commit to the tip of the linux branch which is also up for review.

## Fixes

### Fix 32 bit pointer math bug on 64 bit

This logic worked fine in 32 bit builds, but creates a bug on 64 bit
builds. In 64 bit dllist and rem are 64 bit addresses, not 32 bit
addresses, so (unsigned char*)dllist - (unsigned char*)rem is a 64 bit
ptrdiff_t valule that we are stuffin into a 32 bit int. If that diff is
larger than what would fit in 32 bits it truncates, which leads to the
wrong offset being added to a valid pointer - which leads to garbage
pointers in dlsort.

### Fix off by one error creating buffer overflow

We were looping 2*MINIMAP + 1 positions in each direction, but the
buffer is only sized for 2*MINIMAP pixels per row/column. This lead to
buffer overflow that was caught by AddressSanitizer using an asan build,
at program launch time.

### Fix png memory leak

We were creating end_info but we weren't freeing it. It appears we never
actually use end_info for anything, so the easiest way to fix this is to
simply take it out.

### Fix left shift into sign bit
When running a build of the game with zig as the C compiler, with the
sanitize_c setting set to full, we get a detection on launch that when
IRGBA get's used, then a left shift of the alpha channel by 24 shifts it
into the sign bit, which is undefined behavior. This casts each channel
to unsigned before shifting so a left shift by 24 is always
representable, assuming values are always constrained to 0-255.

### Fixed detected left shift of negative value
A sanitize build detected a left shift of -1 on startup. My guess is
that flags is somehow becoming large enough to overflow into the sign
bit from a caller - this casts to uint32_t for both (all other values
here are already uint32_t) which fixes the undefined behavior.

For posterity, the fix from the linux build is this:

### Fix misaligned network read/write in client

We were relying on casting byte buffers to wider integer/struct
pointers, which is undefined behavior in C and triggers alignment errors
under sanitizers (and can trap on non-x86). This change makes network
reads/writes alignment-safe so the client is sanitizer-clean and more
portable, without changing protocol behavior.

^ Fixed here #23 